### PR TITLE
Introducing logging in wp-service

### DIFF
--- a/waardepapieren-service/configuration/waardepapieren-config-compose.json
+++ b/waardepapieren-service/configuration/waardepapieren-config-compose.json
@@ -4,6 +4,7 @@
   "NLX_OUTWAY_ENDPOINT" : "http://mock-nlx:4080",
   "NLX_CERT": "/certs/org.crt",
   "NLX_KEY": "/certs/org.key",
+  "LOG_LEVEL": "info",
   "PRODUCT_NEED" : "BRP_UITTREKSEL_NEED",
   "SOURCE_NLX_PATH" : "/brp/basisregistratie/natuurlijke_personen/bsn/{BSN}",
   "SOURCE_ARGUMENT" : "BSN",

--- a/waardepapieren-service/configuration/waardepapieren-config.json
+++ b/waardepapieren-service/configuration/waardepapieren-config.json
@@ -4,6 +4,7 @@
   "NLX_OUTWAY_ENDPOINT" : "http://localhost:4080",
   "NLX_CERT": "/certs/org.crt",
   "NLX_KEY": "/certs/org.key",
+  "LOG_LEVEL": "info",
   "PRODUCT_NEED" : "BRP_UITTREKSEL_NEED",
   "SOURCE_NLX_PATH" : "/brp/basisregistratie/natuurlijke_personen/bsn/{BSN}",
   "SOURCE_ARGUMENT" : "BSN",

--- a/waardepapieren-service/package-lock.json
+++ b/waardepapieren-service/package-lock.json
@@ -2780,6 +2780,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
+    "loglevel": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
+      "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po="
+    },
     "lolex": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.1.0.tgz",

--- a/waardepapieren-service/package.json
+++ b/waardepapieren-service/package.json
@@ -23,6 +23,7 @@
     "@discipl/core-nlx": "~0.2.0",
     "babel-plugin-dynamic-import-node": "^2.2.0",
     "jsonpath": "^1.0.1",
+    "loglevel": "^1.6.1",
     "rxjs": "^6.4.0",
     "websocket": "^1.0.28"
   },

--- a/waardepapieren-service/src/index.js
+++ b/waardepapieren-service/src/index.js
@@ -1,5 +1,6 @@
 import WaardepapierenService from './waardepapieren-service'
 
+
 import fs from 'fs'
 
 let configurationPath = process.env.WAARDEPAPIEREN_CONFIG || '../configuration/waardepapieren-config.json'

--- a/waardepapieren-service/system-test/index.spec.js
+++ b/waardepapieren-service/system-test/index.spec.js
@@ -32,16 +32,12 @@ describe('waardenpapieren-service', function () {
     let ephemeralConnector = await abundance.getCoreAPI().getConnector('ephemeral')
     ephemeralConnector.configure(CONFIGURATION.EPHEMERAL_ENDPOINT, CONFIGURATION.EPHEMERAL_WEBSOCKET_ENDPOINT, w3cwebsocket)
 
-    console.log('here')
     // Set up need
     let need = await abundance.need('ephemeral', CONFIGURATION.PRODUCT_NEED)
-    console.log("here1.5")
 
     let observeOffer = await abundance.observeOffer(need.theirPrivateDid, need.myPrivateSsid)
-    console.log('here1.7')
     await observeOffer.readyPromise
 
-    console.log("here2")
 
     await abundance.getCoreAPI().claim(need.myPrivateSsid, {[CONFIGURATION.SOURCE_ARGUMENT]: '663678651'})
 

--- a/waardepapieren-service/test/index.spec.js
+++ b/waardepapieren-service/test/index.spec.js
@@ -30,6 +30,7 @@ describe('waardenpapieren-service, integrated with mocked nlx connector', functi
 
     CONFIGURATION.NLX_CERT='./system-test/certs/org.crt'
     CONFIGURATION.NLX_KEY='./system-test/certs/org.key'
+    CONFIGURATION.LOG_LEVEL='info'
 
     // Set up server
     let waardenpapierenService = new WaardenpapierenService()


### PR DESCRIPTION
I've chosen the loglevel library to introduce logging, since it allows us to turn it on/off and have logging at different levels.