### PR TITLE
Saved qrString in state to be re-used in other functions

### DIFF
--- a/validator-frontend/screens/ScanScreen.js
+++ b/validator-frontend/screens/ScanScreen.js
@@ -75,6 +75,7 @@ class ValidatingScreen extends Component {
   async _checkQR() {
     const { navigation } = this.props;
     const qrString = await navigation.getParam('qrString', 'String not found');
+    this.setState({qrString: qrString})
     let cert =  '   -----BEGIN CERTIFICATE-----  '  +
       '   MIIFzzCCA7egAwIBAgIUBDAnPgMV5iH+LkMfm6h5E8jWVOswDQYJKoZIhvcNAQEN  '  +
       '   BQAwXzELMAkGA1UEBhMCTkwxFjAUBgNVBAgTDU5vb3JkLUhvbGxhbmQxEjAQBgNV  '  +
@@ -127,7 +128,7 @@ class ValidatingScreen extends Component {
     }
     else if(this.result == true){
       this.setState({validatingState: "verified"})
-      this._storeData(this.qrString)
+      this._storeData(this.state.qrString)
     }
   };
 


### PR DESCRIPTION
Due to the migration of the _storeData() function from the scan screen to the validating screen (because the string should only be saved when the string is verified), code was copied to the validating class. It was not however, verified that a string actually got saved because the string stays in the memory of the app. 

This pull request puts the qrString in the state within validating screen so the function can get accessed from other functions from the validating screen, like the wrapperFunction that calls _storeData().