### PR TITLE
Added camera permission message in a plist object in app.json

### DIFF
--- a/validator-frontend/app.json
+++ b/validator-frontend/app.json
@@ -21,6 +21,9 @@
       "**/*"
     ],
     "ios": {
+      "infoPlist": {
+        "NSCameraUsageDescription": "This app uses the camera to scan QR-codes on documents that are signed with the waardepapieren-service to validate said documents."
+      },
       "supportsTablet": true
     }
   }


### PR DESCRIPTION
This fix was made conform the requirements send by the apple testing team for the app. The message should now be automatically included in a plist file instead of only hardcoded in app